### PR TITLE
Fixing Application Null Reference in XpandSecurityModule.cs

### DIFF
--- a/Xpand/Xpand.ExpressApp.Modules/Security/XpandSecurityModule.cs
+++ b/Xpand/Xpand.ExpressApp.Modules/Security/XpandSecurityModule.cs
@@ -19,10 +19,15 @@ namespace Xpand.ExpressApp.Security {
 
         public override void CustomizeTypesInfo(ITypesInfo typesInfo) {
             base.CustomizeTypesInfo(typesInfo);
-            var roleTypeProvider = Application.Security as IRoleTypeProvider;
-            if (roleTypeProvider != null) {
-                foreach (var attribute in SecurityOperationsAttributes(typesInfo)) {
-                    CreateMember(typesInfo, roleTypeProvider, attribute);
+            if (Application != null)
+            {
+                var roleTypeProvider = Application.Security as IRoleTypeProvider;
+                if (roleTypeProvider != null)
+                {
+                    foreach (var attribute in SecurityOperationsAttributes(typesInfo))
+                    {
+                        CreateMember(typesInfo, roleTypeProvider, attribute);
+                    }
                 }
             }
         }


### PR DESCRIPTION
When updating the module in VS, the Application is null and this causes a null reference. I just added a check for if (Application != null)
