### PR TITLE
SelectedObjects returns instances of wrong types

### DIFF
--- a/Xpand/Xpand.ExpressApp/Xpand.ExpressApp/XpandListView.cs
+++ b/Xpand/Xpand.ExpressApp/Xpand.ExpressApp/XpandListView.cs
@@ -39,5 +39,19 @@ namespace Xpand.ExpressApp {
             if (Model != null)
                 args.Handled = !((IModelObjectViewPersistModelModifications)Model).PersistModelModifications;
         }
+        public override IList SelectedObjects
+        {
+            get
+            {
+                if (Editor != null)
+                {
+                    return new List<Object>(Editor.GetSelectedObjects() as IList<Object>).Where(t => ObjectTypeInfo.Type.IsAssignableFrom(t.GetType())).ToArray();
+                }
+                else
+                {
+                    return new ReadOnlyCollection<object>(new object[0] { });
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
SelectedObjects returns instances of the selected rows even if they are of a different type than ObjectTypeInfo.Type of the view.
If you use security than expanding a master row of a master detail grid throws an exception because SelectedObjects of the detail view returns the object belonging to the currently selected row, which apparently is of the master type. This is perhaps not the whole solution as i don't think that Editor.GetSelectedObjects() will be correct if Master and Detail rows are selected but it at least "solves" the exception problem.
