### PR TITLE
Update MapListEditor.cs

### DIFF
--- a/Xpand/Xpand.ExpressApp.Modules/MapView.Web/MapListEditor.cs
+++ b/Xpand/Xpand.ExpressApp.Modules/MapView.Web/MapListEditor.cs
@@ -64,10 +64,10 @@ namespace Xpand.ExpressApp.MapView.Web {
                 string address = GetMemberValueToString(obj, mapView.AddressMember);
                 if (!string.IsNullOrEmpty(address)) {
                     mapViewInfo.Address = address;
-                    mapViewInfo.InfoWindowText  = GetMemberValueToString(obj, mapView.InfoWindowTextMember);
-                
                 }
-
+                
+                mapViewInfo.InfoWindowText  = GetMemberValueToString(obj, mapView.InfoWindowTextMember);
+                
                 mapViewInfo.Latitude = GetMemberValue<decimal?>(obj, mapView.LatitudeMember);
                 mapViewInfo.Longitude = GetMemberValue<decimal?>(obj, mapView.LongitudeMember);
                 mapViewInfos.Add(mapViewInfo);


### PR DESCRIPTION
If there is no address property or if has a null value then the InfoWindowText property is ignored rendering the information balloon useless. This can be fixed getting the line that gets the text out of the if that checks if the address is empty.
